### PR TITLE
Fix for cache size calculation

### DIFF
--- a/ngx_cache_purge_module.c
+++ b/ngx_cache_purge_module.c
@@ -762,6 +762,7 @@ ngx_http_file_cache_purge(ngx_http_request_t *r)
 #  endif
 
     c->node->exists = 0;
+    c->node->fs_size = 0;
 #  if defined(nginx_version) \
       && ((nginx_version >= 8001) \
           || ((nginx_version < 8000) && (nginx_version >= 7060)))


### PR DESCRIPTION
When a file is requested again after it has been purged, nginx will substract
the size of the cached file again in:

http://trac.nginx.org/nginx/browser/nginx/trunk/src/http/ngx_http_file_cache.c?rev=4341#L837

Because of that nginx will use more cache space than it should.

Setting c->node->fs_size to zero fixes the issue.
