### PR TITLE
cplcf->conf->purge_all causing segmentation fault

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -1,0 +1,22 @@
+# astylerc
+align-pointer=name
+align-reference=name
+break-after-logical
+#indent=spaces=2
+max-code-length=120
+style=google
+suffix=none
+
+# Indent
+indent-preproc-block
+
+# Padding
+pad-header
+unpad-paren
+
+# Formatting:
+add-brackets
+#convert-tabs
+
+# Output:
+formatted

--- a/.format.sh
+++ b/.format.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Search in the script folder
+pushd "$(dirname $0)" >/dev/null
+CWD="$(pwd -P)"
+popd >/dev/null
+FILES='ngx_cache_purge_module.c'
+
+# The file format in accordance with the style defined in .astylerc
+astyle -v --options='.astylerc' ${FILES} || (echo 'astyle failed'; exit 1);
+
+# To correct this, the issuance dos2unix on each file
+# sometimes adds in Windows as a string-endins (\r\n).
+dos2unix --quiet ${FILES} || (echo 'dos2unix failed'; exit 2);

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.t linguist-language=Text

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,50 @@
+sudo: required
+os: linux
+dist: trusty
+language: c
+compiler:
+  - gcc
+  - clang
+cache:
+  apt: true
+  directories:
+    - download-cache
+env:
+  global:
+    - JOBS=4
+    - NGINX_VERSION=1.12.0
+    - NGINX_PREFIX=/opt/nginx
+    - OPENSSL_PREFIX=/opt/ssl
+    - OPENSSL_LIB=$OPENSSL_PREFIX/lib
+    - OPENSSL_INC=$OPENSSL_PREFIX/include
+    - OPENSSL_VER=1.0.2k
+
+before_install:
+  - sudo apt-get install -qq -y cpanminus
+
+install:
+  - if [ ! -d /opt ]; then mkdir /opt; fi
+  - if [ ! -d download-cache ]; then mkdir download-cache; fi
+  - if [ ! -f download-cache/nginx-$NGINX_VERSION.tar.gz ]; then wget -O download-cache/nginx-$NGINX_VERSION.tar.gz http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz; fi
+  - if [ ! -f download-cache/openssl-$OPENSSL_VER.tar.gz ]; then wget -O download-cache/openssl-$OPENSSL_VER.tar.gz https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz; fi
+  - git clone https://github.com/openresty/test-nginx.git
+
+script:
+  - cd test-nginx/ && sudo cpanm . && cd ..
+  - tar zxf download-cache/openssl-$OPENSSL_VER.tar.gz
+  - cd openssl-$OPENSSL_VER/
+  - ./config shared --prefix=$OPENSSL_PREFIX -DPURIFY > build.log 2>&1 || (cat build.log && exit 1)
+  - make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
+  - sudo make PATH=$PATH install_sw > build.log 2>&1 || (cat build.log && exit 1)
+  - cd ..
+  - tar zxf download-cache/nginx-$NGINX_VERSION.tar.gz
+  - cd nginx-$NGINX_VERSION/
+  - ./configure --prefix=$NGINX_PREFIX --with-debug --add-module=$PWD/.. > build.log 2>&1 || (cat build.log && exit 1)
+  - make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
+  - sudo make install > build.log 2>&1 || (cat build.log && exit 1)
+  - cd ..
+  - export PATH=$NGINX_PREFIX/sbin:$PATH
+#  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+  - nginx -V
+  - ldd `which nginx`
+  - prove t

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,21 @@
+2016-11-20    VERSION 2.4
+    * Fix compatibility with nginx-1.7.12+.
+    * explain the purge logic
+    * feat(purge all): Include option to purge all the cached files
+      This option can be slow if a lot of content is cached, or if the
+      storage used for the cache is slow. But you really should be using
+      RAM as your cache storage.
+    * feat(partial keys): Support partial keys to purge multiple keys.
+      Put an '*' at the end of your purge cache URL.
+      e.g:
+          proxy_cache_key $scheme$host$uri$is_args$args$cookie_JSESSIONID;
+          curl -X PURGE https://example.com/pass*
+      This will remove every cached page whose key cache starting with:
+          httpsexample.com/pass*
+      Be careful not passing any value for the values after the $uri, or put
+      it at the end of your cache key.
+    * Convert a config file to build a dynamic module
+
 2014-12-23    VERSION 2.3
     * Fix compatibility with nginx-1.7.9+.
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+2017-02-21    VERSION 2.4.1
+    * Fix compatibility with nginx-1.11.6+, Sułowicz Paweł
+
 2016-11-20    VERSION 2.4
     * Fix compatibility with nginx-1.7.12+.
     * explain the purge logic

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 About
 =====
 `ngx_cache_purge` is `nginx` module which adds ability to purge content from
-`FastCGI`, `proxy`, `SCGI` and `uWSGI` caches.
+`FastCGI`, `proxy`, `SCGI` and `uWSGI` caches. A purge operation removes the 
+content with the same cache key as the purge request has.
 
 
 Sponsors

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Configuration directives (same location syntax)
 ===============================================
 fastcgi_cache_purge
 -------------------
-* **syntax**: `fastcgi_cache_purge on|off|<method> [from all|<ip> [.. <ip>]]`
+* **syntax**: `fastcgi_cache_purge on|off|<method> [purge_all] [from all|<ip> [.. <ip>]]`
 * **default**: `none`
 * **context**: `http`, `server`, `location`
 
@@ -28,7 +28,7 @@ Allow purging of selected pages from `FastCGI`'s cache.
 
 proxy_cache_purge
 -----------------
-* **syntax**: `proxy_cache_purge on|off|<method> [from all|<ip> [.. <ip>]]`
+* **syntax**: `proxy_cache_purge on|off|<method> [purge_all] [from all|<ip> [.. <ip>]]`
 * **default**: `none`
 * **context**: `http`, `server`, `location`
 
@@ -37,7 +37,7 @@ Allow purging of selected pages from `proxy`'s cache.
 
 scgi_cache_purge
 ----------------
-* **syntax**: `scgi_cache_purge on|off|<method> [from all|<ip> [.. <ip>]]`
+* **syntax**: `scgi_cache_purge on|off|<method> [purge_all] [from all|<ip> [.. <ip>]]`
 * **default**: `none`
 * **context**: `http`, `server`, `location`
 
@@ -46,7 +46,7 @@ Allow purging of selected pages from `SCGI`'s cache.
 
 uwsgi_cache_purge
 -----------------
-* **syntax**: `uwsgi_cache_purge on|off|<method> [from all|<ip> [.. <ip>]]`
+* **syntax**: `uwsgi_cache_purge on|off|<method> [purge_all] [from all|<ip> [.. <ip>]]`
 * **default**: `none`
 * **context**: `http`, `server`, `location`
 
@@ -102,6 +102,22 @@ Sample configuration (same location syntax)
                 proxy_cache        tmpcache;
                 proxy_cache_key    $uri$is_args$args;
                 proxy_cache_purge  PURGE from 127.0.0.1;
+            }
+        }
+    }
+
+
+Sample configuration (same location syntax - purge all cached files)
+====================================================================
+    http {
+        proxy_cache_path  /tmp/cache  keys_zone=tmpcache:10m;
+
+        server {
+            location / {
+                proxy_pass         http://127.0.0.1:8000;
+                proxy_cache        tmpcache;
+                proxy_cache_key    $uri$is_args$args;
+                proxy_cache_purge  PURGE purge_all from 127.0.0.1;
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ uwsgi_cache_purge
 Sets area and key used for purging selected pages from `uWSGI`'s cache.
 
 
+
+Partial Keys
+============
+Sometimes it's not possible to pass the exact key cache to purge a page. For example; when the content of a cookie or the params are part of the key.
+You can specify a partial key adding an asterisk at the end of the URL.
+
+    curl -X PURGE /page*
+
+The asterisk must be the last character of the key, so you **must** put the $uri variable at the end.
+
+
+
 Sample configuration (same location syntax)
 ===========================================
     http {

--- a/config
+++ b/config
@@ -15,7 +15,17 @@ if [ "$HTTP_UWSGI" = "YES" ]; then
 fi
 
 ngx_addon_name=ngx_http_cache_purge_module
-HTTP_MODULES="$HTTP_MODULES ngx_http_cache_purge_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_cache_purge_module.c"
+CACHE_PURGE_SRCS="$ngx_addon_dir/ngx_cache_purge_module.c"
+
+if [ -n "$ngx_module_link" ]; then
+    ngx_module_type=HTTP
+    ngx_module_name="$ngx_addon_name"
+    ngx_module_srcs="$CACHE_PURGE_SRCS"
+
+    . auto/module
+else
+    HTTP_MODULES="$HTTP_MODULES $ngx_addon_name"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $CACHE_PURGE_SRCS"
+fi
 
 have=NGX_CACHE_PURGE_MODULE . auto/have

--- a/ngx_cache_purge_module.c
+++ b/ngx_cache_purge_module.c
@@ -518,7 +518,11 @@ typedef struct {
     ngx_str_t                      body_source;
 #  endif /* nginx_version < 1007008 */
 
+#  if (nginx_version >= 1011006)
+    ngx_http_complex_value_t      *method;
+#  else
     ngx_str_t                      method;
+#  endif /* nginx_version >= 1011006 */
     ngx_str_t                      location;
     ngx_str_t                      url;
 

--- a/ngx_cache_purge_module.c
+++ b/ngx_cache_purge_module.c
@@ -34,7 +34,7 @@
 
 
 #ifndef nginx_version
-#error This module cannot be build against an unknown nginx version.
+    #error This module cannot be build against an unknown nginx version.
 #endif
 
 
@@ -69,25 +69,25 @@ typedef struct {
 
 # if (NGX_HTTP_FASTCGI)
 char       *ngx_http_fastcgi_cache_purge_conf(ngx_conf_t *cf,
-                ngx_command_t *cmd, void *conf);
+        ngx_command_t *cmd, void *conf);
 ngx_int_t   ngx_http_fastcgi_cache_purge_handler(ngx_http_request_t *r);
 # endif /* NGX_HTTP_FASTCGI */
 
 # if (NGX_HTTP_PROXY)
 char       *ngx_http_proxy_cache_purge_conf(ngx_conf_t *cf,
-                ngx_command_t *cmd, void *conf);
+        ngx_command_t *cmd, void *conf);
 ngx_int_t   ngx_http_proxy_cache_purge_handler(ngx_http_request_t *r);
 # endif /* NGX_HTTP_PROXY */
 
 # if (NGX_HTTP_SCGI)
 char       *ngx_http_scgi_cache_purge_conf(ngx_conf_t *cf,
-                ngx_command_t *cmd, void *conf);
+        ngx_command_t *cmd, void *conf);
 ngx_int_t   ngx_http_scgi_cache_purge_handler(ngx_http_request_t *r);
 # endif /* NGX_HTTP_SCGI */
 
 # if (NGX_HTTP_UWSGI)
 char       *ngx_http_uwsgi_cache_purge_conf(ngx_conf_t *cf,
-                ngx_command_t *cmd, void *conf);
+        ngx_command_t *cmd, void *conf);
 ngx_int_t   ngx_http_uwsgi_cache_purge_handler(ngx_http_request_t *r);
 # endif /* NGX_HTTP_UWSGI */
 
@@ -98,15 +98,15 @@ ngx_http_purge_file_cache_delete_file(ngx_tree_ctx_t *ctx, ngx_str_t *path);
 
 ngx_int_t   ngx_http_cache_purge_access_handler(ngx_http_request_t *r);
 ngx_int_t   ngx_http_cache_purge_access(ngx_array_t *a, ngx_array_t *a6,
-    struct sockaddr *s);
+                                        struct sockaddr *s);
 
 ngx_int_t   ngx_http_cache_purge_send_response(ngx_http_request_t *r);
 # if (nginx_version >= 1007009)
 ngx_int_t   ngx_http_cache_purge_cache_get(ngx_http_request_t *r,
-    ngx_http_upstream_t *u, ngx_http_file_cache_t **cache);
+        ngx_http_upstream_t *u, ngx_http_file_cache_t **cache);
 # endif /* nginx_version >= 1007009 */
 ngx_int_t   ngx_http_cache_purge_init(ngx_http_request_t *r,
-    ngx_http_file_cache_t *cache, ngx_http_complex_value_t *cache_key);
+                                      ngx_http_file_cache_t *cache, ngx_http_complex_value_t *cache_key);
 void        ngx_http_cache_purge_handler(ngx_http_request_t *r);
 
 ngx_int_t   ngx_http_file_cache_purge(ngx_http_request_t *r);
@@ -117,51 +117,59 @@ void        ngx_http_cache_purge_partial(ngx_http_request_t *r, ngx_http_file_ca
 ngx_int_t   ngx_http_cache_purge_is_partial(ngx_http_request_t *r);
 
 char       *ngx_http_cache_purge_conf(ngx_conf_t *cf,
-    ngx_http_cache_purge_conf_t *cpcf);
+                                      ngx_http_cache_purge_conf_t *cpcf);
 
 void       *ngx_http_cache_purge_create_loc_conf(ngx_conf_t *cf);
 char       *ngx_http_cache_purge_merge_loc_conf(ngx_conf_t *cf,
-    void *parent, void *child);
+        void *parent, void *child);
 
 static ngx_command_t  ngx_http_cache_purge_module_commands[] = {
 
 # if (NGX_HTTP_FASTCGI)
-    { ngx_string("fastcgi_cache_purge"),
-      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_1MORE,
-      ngx_http_fastcgi_cache_purge_conf,
-      NGX_HTTP_LOC_CONF_OFFSET,
-      0,
-      NULL },
+    {
+        ngx_string("fastcgi_cache_purge"),
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_1MORE,
+        ngx_http_fastcgi_cache_purge_conf,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        0,
+        NULL
+    },
 # endif /* NGX_HTTP_FASTCGI */
 
 # if (NGX_HTTP_PROXY)
-    { ngx_string("proxy_cache_purge"),
-      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_1MORE,
-      ngx_http_proxy_cache_purge_conf,
-      NGX_HTTP_LOC_CONF_OFFSET,
-      0,
-      NULL },
+    {
+        ngx_string("proxy_cache_purge"),
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_1MORE,
+        ngx_http_proxy_cache_purge_conf,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        0,
+        NULL
+    },
 # endif /* NGX_HTTP_PROXY */
 
 # if (NGX_HTTP_SCGI)
-    { ngx_string("scgi_cache_purge"),
-      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_1MORE,
-      ngx_http_scgi_cache_purge_conf,
-      NGX_HTTP_LOC_CONF_OFFSET,
-      0,
-      NULL },
+    {
+        ngx_string("scgi_cache_purge"),
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_1MORE,
+        ngx_http_scgi_cache_purge_conf,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        0,
+        NULL
+    },
 # endif /* NGX_HTTP_SCGI */
 
 # if (NGX_HTTP_UWSGI)
-    { ngx_string("uwsgi_cache_purge"),
-      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_1MORE,
-      ngx_http_uwsgi_cache_purge_conf,
-      NGX_HTTP_LOC_CONF_OFFSET,
-      0,
-      NULL },
+    {
+        ngx_string("uwsgi_cache_purge"),
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_1MORE,
+        ngx_http_uwsgi_cache_purge_conf,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        0,
+        NULL
+    },
 # endif /* NGX_HTTP_UWSGI */
 
-      ngx_null_command
+    ngx_null_command
 };
 
 static ngx_http_module_t  ngx_http_cache_purge_module_ctx = {
@@ -194,18 +202,18 @@ ngx_module_t  ngx_http_cache_purge_module = {
 };
 
 static char ngx_http_cache_purge_success_page_top[] =
-"<html>" CRLF
-"<head><title>Successful purge</title></head>" CRLF
-"<body bgcolor=\"white\">" CRLF
-"<center><h1>Successful purge</h1>" CRLF
-;
+    "<html>" CRLF
+    "<head><title>Successful purge</title></head>" CRLF
+    "<body bgcolor=\"white\">" CRLF
+    "<center><h1>Successful purge</h1>" CRLF
+    ;
 
 static char ngx_http_cache_purge_success_page_tail[] =
-CRLF "</center>" CRLF
-"<hr><center>" NGINX_VER "</center>" CRLF
-"</body>" CRLF
-"</html>" CRLF
-;
+    CRLF "</center>" CRLF
+    "<hr><center>" NGINX_VER "</center>" CRLF
+    "</body>" CRLF
+    "</html>" CRLF
+    ;
 
 # if (NGX_HTTP_FASTCGI)
 extern ngx_module_t  ngx_http_fastcgi_module;
@@ -269,8 +277,7 @@ typedef struct {
 
 char *
 ngx_http_fastcgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd,
-    void *conf)
-{
+                                  void *conf) {
     ngx_http_compile_complex_value_t   ccv;
     ngx_http_cache_purge_loc_conf_t   *cplcf;
     ngx_http_core_loc_conf_t          *clcf;
@@ -301,7 +308,7 @@ ngx_http_fastcgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd,
     if (flcf->upstream.cache > 0)
 #  else
     if (flcf->upstream.cache != NGX_CONF_UNSET_PTR
-        && flcf->upstream.cache != NULL)
+            && flcf->upstream.cache != NULL)
 #  endif /* nginx_version >= 1007009 */
     {
         return "is incompatible with \"fastcgi_cache\"";
@@ -313,10 +320,9 @@ ngx_http_fastcgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd,
 
     if (flcf->upstream.store > 0
 #  if (nginx_version < 1007009)
-        || flcf->upstream.store_lengths
+            || flcf->upstream.store_lengths
 #  endif /* nginx_version >= 1007009 */
-       )
-    {
+       ) {
         return "is incompatible with \"fastcgi_store\"";
     }
 
@@ -340,7 +346,7 @@ ngx_http_fastcgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd,
     if (cv.lengths != NULL) {
 
         flcf->upstream.cache_value = ngx_palloc(cf->pool,
-                                             sizeof(ngx_http_complex_value_t));
+                                                sizeof(ngx_http_complex_value_t));
         if (flcf->upstream.cache_value == NULL) {
             return NGX_CONF_ERROR;
         }
@@ -350,7 +356,7 @@ ngx_http_fastcgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd,
     } else {
 
         flcf->upstream.cache_zone = ngx_shared_memory_add(cf, &value[1], 0,
-                                                     &ngx_http_fastcgi_module);
+                                    &ngx_http_fastcgi_module);
         if (flcf->upstream.cache_zone == NULL) {
             return NGX_CONF_ERROR;
         }
@@ -359,7 +365,7 @@ ngx_http_fastcgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd,
 #  else
 
     flcf->upstream.cache = ngx_shared_memory_add(cf, &value[1], 0,
-                                                 &ngx_http_fastcgi_module);
+                           &ngx_http_fastcgi_module);
     if (flcf->upstream.cache == NULL) {
         return NGX_CONF_ERROR;
     }
@@ -387,8 +393,7 @@ ngx_http_fastcgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd,
 }
 
 ngx_int_t
-ngx_http_fastcgi_cache_purge_handler(ngx_http_request_t *r)
-{
+ngx_http_fastcgi_cache_purge_handler(ngx_http_request_t *r) {
     ngx_http_file_cache_t               *cache;
     ngx_http_fastcgi_loc_conf_t         *flcf;
     ngx_http_cache_purge_loc_conf_t     *cplcf;
@@ -430,11 +435,10 @@ ngx_http_fastcgi_cache_purge_handler(ngx_http_request_t *r)
     cplcf = ngx_http_get_module_loc_conf(r, ngx_http_cache_purge_module);
     if (cplcf->conf->purge_all) {
         ngx_http_cache_purge_all(r, cache);
-    }
-    else {
+    } else {
         if (ngx_http_cache_purge_is_partial(r)) {
             ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                           "http file cache purge with partial enabled");
+                          "http file cache purge with partial enabled");
 
             ngx_http_cache_purge_partial(r, cache);
         }
@@ -559,8 +563,7 @@ typedef struct {
 } ngx_http_proxy_loc_conf_t;
 
 char *
-ngx_http_proxy_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
-{
+ngx_http_proxy_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf) {
     ngx_http_compile_complex_value_t   ccv;
     ngx_http_cache_purge_loc_conf_t   *cplcf;
     ngx_http_core_loc_conf_t          *clcf;
@@ -591,7 +594,7 @@ ngx_http_proxy_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     if (plcf->upstream.cache > 0)
 #  else
     if (plcf->upstream.cache != NGX_CONF_UNSET_PTR
-        && plcf->upstream.cache != NULL)
+            && plcf->upstream.cache != NULL)
 #  endif /* nginx_version >= 1007009 */
     {
         return "is incompatible with \"proxy_cache\"";
@@ -603,10 +606,9 @@ ngx_http_proxy_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     if (plcf->upstream.store > 0
 #  if (nginx_version < 1007009)
-        || plcf->upstream.store_lengths
+            || plcf->upstream.store_lengths
 #  endif /* nginx_version >= 1007009 */
-       )
-    {
+       ) {
         return "is incompatible with \"proxy_store\"";
     }
 
@@ -630,7 +632,7 @@ ngx_http_proxy_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     if (cv.lengths != NULL) {
 
         plcf->upstream.cache_value = ngx_palloc(cf->pool,
-                                             sizeof(ngx_http_complex_value_t));
+                                                sizeof(ngx_http_complex_value_t));
         if (plcf->upstream.cache_value == NULL) {
             return NGX_CONF_ERROR;
         }
@@ -640,7 +642,7 @@ ngx_http_proxy_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     } else {
 
         plcf->upstream.cache_zone = ngx_shared_memory_add(cf, &value[1], 0,
-                                                       &ngx_http_proxy_module);
+                                    &ngx_http_proxy_module);
         if (plcf->upstream.cache_zone == NULL) {
             return NGX_CONF_ERROR;
         }
@@ -649,7 +651,7 @@ ngx_http_proxy_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 #  else
 
     plcf->upstream.cache = ngx_shared_memory_add(cf, &value[1], 0,
-                                                 &ngx_http_proxy_module);
+                           &ngx_http_proxy_module);
     if (plcf->upstream.cache == NULL) {
         return NGX_CONF_ERROR;
     }
@@ -677,8 +679,7 @@ ngx_http_proxy_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 }
 
 ngx_int_t
-ngx_http_proxy_cache_purge_handler(ngx_http_request_t *r)
-{
+ngx_http_proxy_cache_purge_handler(ngx_http_request_t *r) {
     ngx_http_file_cache_t               *cache;
     ngx_http_proxy_loc_conf_t           *plcf;
     ngx_http_cache_purge_loc_conf_t     *cplcf;
@@ -720,11 +721,10 @@ ngx_http_proxy_cache_purge_handler(ngx_http_request_t *r)
     cplcf = ngx_http_get_module_loc_conf(r, ngx_http_cache_purge_module);
     if (cplcf->conf->purge_all) {
         ngx_http_cache_purge_all(r, cache);
-    }
-    else {
+    } else {
         if (ngx_http_cache_purge_is_partial(r)) {
             ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                           "http file cache purge with partial enabled");
+                          "http file cache purge with partial enabled");
 
             ngx_http_cache_purge_partial(r, cache);
         }
@@ -787,8 +787,7 @@ typedef struct {
 } ngx_http_scgi_loc_conf_t;
 
 char *
-ngx_http_scgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
-{
+ngx_http_scgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf) {
     ngx_http_compile_complex_value_t   ccv;
     ngx_http_cache_purge_loc_conf_t   *cplcf;
     ngx_http_core_loc_conf_t          *clcf;
@@ -819,7 +818,7 @@ ngx_http_scgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     if (slcf->upstream.cache > 0)
 #  else
     if (slcf->upstream.cache != NGX_CONF_UNSET_PTR
-        && slcf->upstream.cache != NULL)
+            && slcf->upstream.cache != NULL)
 #  endif /* nginx_version >= 1007009 */
     {
         return "is incompatible with \"scgi_cache\"";
@@ -831,10 +830,9 @@ ngx_http_scgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     if (slcf->upstream.store > 0
 #  if (nginx_version < 1007009)
-        || slcf->upstream.store_lengths
+            || slcf->upstream.store_lengths
 #  endif /* nginx_version >= 1007009 */
-       )
-    {
+       ) {
         return "is incompatible with \"scgi_store\"";
     }
 
@@ -858,7 +856,7 @@ ngx_http_scgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     if (cv.lengths != NULL) {
 
         slcf->upstream.cache_value = ngx_palloc(cf->pool,
-                                             sizeof(ngx_http_complex_value_t));
+                                                sizeof(ngx_http_complex_value_t));
         if (slcf->upstream.cache_value == NULL) {
             return NGX_CONF_ERROR;
         }
@@ -868,7 +866,7 @@ ngx_http_scgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     } else {
 
         slcf->upstream.cache_zone = ngx_shared_memory_add(cf, &value[1], 0,
-                                                        &ngx_http_scgi_module);
+                                    &ngx_http_scgi_module);
         if (slcf->upstream.cache_zone == NULL) {
             return NGX_CONF_ERROR;
         }
@@ -877,7 +875,7 @@ ngx_http_scgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 #  else
 
     slcf->upstream.cache = ngx_shared_memory_add(cf, &value[1], 0,
-                                                 &ngx_http_scgi_module);
+                           &ngx_http_scgi_module);
     if (slcf->upstream.cache == NULL) {
         return NGX_CONF_ERROR;
     }
@@ -905,8 +903,7 @@ ngx_http_scgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 }
 
 ngx_int_t
-ngx_http_scgi_cache_purge_handler(ngx_http_request_t *r)
-{
+ngx_http_scgi_cache_purge_handler(ngx_http_request_t *r) {
     ngx_http_file_cache_t               *cache;
     ngx_http_scgi_loc_conf_t            *slcf;
     ngx_http_cache_purge_loc_conf_t     *cplcf;
@@ -948,11 +945,10 @@ ngx_http_scgi_cache_purge_handler(ngx_http_request_t *r)
     cplcf = ngx_http_get_module_loc_conf(r, ngx_http_cache_purge_module);
     if (cplcf->conf->purge_all) {
         ngx_http_cache_purge_all(r, cache);
-    }
-    else {
+    } else {
         if (ngx_http_cache_purge_is_partial(r)) {
             ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                           "http file cache purge with partial enabled");
+                          "http file cache purge with partial enabled");
 
             ngx_http_cache_purge_partial(r, cache);
         }
@@ -1038,8 +1034,7 @@ typedef struct {
 } ngx_http_uwsgi_loc_conf_t;
 
 char *
-ngx_http_uwsgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
-{
+ngx_http_uwsgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf) {
     ngx_http_compile_complex_value_t   ccv;
     ngx_http_cache_purge_loc_conf_t   *cplcf;
     ngx_http_core_loc_conf_t          *clcf;
@@ -1070,7 +1065,7 @@ ngx_http_uwsgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     if (ulcf->upstream.cache > 0)
 #  else
     if (ulcf->upstream.cache != NGX_CONF_UNSET_PTR
-        && ulcf->upstream.cache != NULL)
+            && ulcf->upstream.cache != NULL)
 #  endif /* nginx_version >= 1007009 */
     {
         return "is incompatible with \"uwsgi_cache\"";
@@ -1082,10 +1077,9 @@ ngx_http_uwsgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     if (ulcf->upstream.store > 0
 #  if (nginx_version < 1007009)
-        || ulcf->upstream.store_lengths
+            || ulcf->upstream.store_lengths
 #  endif /* nginx_version >= 1007009 */
-       )
-    {
+       ) {
         return "is incompatible with \"uwsgi_store\"";
     }
 
@@ -1109,7 +1103,7 @@ ngx_http_uwsgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     if (cv.lengths != NULL) {
 
         ulcf->upstream.cache_value = ngx_palloc(cf->pool,
-                                             sizeof(ngx_http_complex_value_t));
+                                                sizeof(ngx_http_complex_value_t));
         if (ulcf->upstream.cache_value == NULL) {
             return NGX_CONF_ERROR;
         }
@@ -1119,7 +1113,7 @@ ngx_http_uwsgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     } else {
 
         ulcf->upstream.cache_zone = ngx_shared_memory_add(cf, &value[1], 0,
-                                                       &ngx_http_uwsgi_module);
+                                    &ngx_http_uwsgi_module);
         if (ulcf->upstream.cache_zone == NULL) {
             return NGX_CONF_ERROR;
         }
@@ -1128,7 +1122,7 @@ ngx_http_uwsgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 #  else
 
     ulcf->upstream.cache = ngx_shared_memory_add(cf, &value[1], 0,
-                                                 &ngx_http_uwsgi_module);
+                           &ngx_http_uwsgi_module);
     if (ulcf->upstream.cache == NULL) {
         return NGX_CONF_ERROR;
     }
@@ -1156,8 +1150,7 @@ ngx_http_uwsgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 }
 
 ngx_int_t
-ngx_http_uwsgi_cache_purge_handler(ngx_http_request_t *r)
-{
+ngx_http_uwsgi_cache_purge_handler(ngx_http_request_t *r) {
     ngx_http_file_cache_t               *cache;
     ngx_http_uwsgi_loc_conf_t           *ulcf;
     ngx_http_cache_purge_loc_conf_t     *cplcf;
@@ -1199,11 +1192,10 @@ ngx_http_uwsgi_cache_purge_handler(ngx_http_request_t *r)
     cplcf = ngx_http_get_module_loc_conf(r, ngx_http_cache_purge_module);
     if (cplcf->conf->purge_all) {
         ngx_http_cache_purge_all(r, cache);
-    }
-    else {
+    } else {
         if (ngx_http_cache_purge_is_partial(r)) {
             ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                           "http file cache purge with partial enabled");
+                          "http file cache purge with partial enabled");
 
             ngx_http_cache_purge_partial(r, cache);
         }
@@ -1221,14 +1213,12 @@ ngx_http_uwsgi_cache_purge_handler(ngx_http_request_t *r)
 
 
 static ngx_int_t
-ngx_http_purge_file_cache_noop(ngx_tree_ctx_t *ctx, ngx_str_t *path)
-{
+ngx_http_purge_file_cache_noop(ngx_tree_ctx_t *ctx, ngx_str_t *path) {
     return NGX_OK;
 }
 
 static ngx_int_t
-ngx_http_purge_file_cache_delete_file(ngx_tree_ctx_t *ctx, ngx_str_t *path)
-{
+ngx_http_purge_file_cache_delete_file(ngx_tree_ctx_t *ctx, ngx_str_t *path) {
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
                    "http file cache delete: \"%s\"", path->data);
 
@@ -1242,8 +1232,7 @@ ngx_http_purge_file_cache_delete_file(ngx_tree_ctx_t *ctx, ngx_str_t *path)
 
 
 static ngx_int_t
-ngx_http_purge_file_cache_delete_partial_file(ngx_tree_ctx_t *ctx, ngx_str_t *path)
-{
+ngx_http_purge_file_cache_delete_partial_file(ngx_tree_ctx_t *ctx, ngx_str_t *path) {
     u_char *key_partial;
     u_char *key_in_file;
     ngx_uint_t len;
@@ -1257,13 +1246,12 @@ ngx_http_purge_file_cache_delete_partial_file(ngx_tree_ctx_t *ctx, ngx_str_t *pa
         ngx_log_debug(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
                       "empty key_partial, forcing deletion");
         remove_file = 1;
-    }
-    else {
+    } else {
         ngx_file_t file;
 
         file.offset = file.sys_offset = 0;
         file.fd = ngx_open_file(path->data, NGX_FILE_RDONLY, NGX_FILE_OPEN,
-                            NGX_FILE_DEFAULT_ACCESS);
+                                NGX_FILE_DEFAULT_ACCESS);
 
         /* I don't know if it's a good idea to use the ngx_cycle pool for this,
            but the request is not available here */
@@ -1279,42 +1267,39 @@ ngx_http_purge_file_cache_delete_partial_file(ngx_tree_ctx_t *ctx, ngx_str_t *pa
         ngx_close_file(file.fd);
 
         ngx_log_debug2(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
-                        "http cache file \"%s\" key read: \"%s\"", path->data, key_in_file);
+                       "http cache file \"%s\" key read: \"%s\"", path->data, key_in_file);
 
         if (ngx_strncasecmp(key_in_file, key_partial, len) == 0) {
             ngx_log_debug(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
-                      "match found, deleting file \"%s\"", path->data);
+                          "match found, deleting file \"%s\"", path->data);
             remove_file = 1;
         }
     }
 
     if (remove_file && ngx_delete_file(path->data) == NGX_FILE_ERROR) {
         ngx_log_error(NGX_LOG_CRIT, ctx->log, ngx_errno,
-                        ngx_delete_file_n " \"%s\" failed", path->data);
+                      ngx_delete_file_n " \"%s\" failed", path->data);
     }
 
     return NGX_OK;
 }
 
 ngx_int_t
-ngx_http_cache_purge_access_handler(ngx_http_request_t *r)
-{
+ngx_http_cache_purge_access_handler(ngx_http_request_t *r) {
     ngx_http_cache_purge_loc_conf_t   *cplcf;
 
     cplcf = ngx_http_get_module_loc_conf(r, ngx_http_cache_purge_module);
 
     if (r->method_name.len != cplcf->conf->method.len
-        || (ngx_strncmp(r->method_name.data, cplcf->conf->method.data,
-                        r->method_name.len)))
-    {
+            || (ngx_strncmp(r->method_name.data, cplcf->conf->method.data,
+                            r->method_name.len))) {
         return cplcf->original_handler(r);
     }
 
     if ((cplcf->conf->access || cplcf->conf->access6)
-         && ngx_http_cache_purge_access(cplcf->conf->access,
-                                        cplcf->conf->access6,
-                                        r->connection->sockaddr) != NGX_OK)
-    {
+            && ngx_http_cache_purge_access(cplcf->conf->access,
+                                           cplcf->conf->access6,
+                                           r->connection->sockaddr) != NGX_OK) {
         return NGX_HTTP_FORBIDDEN;
     }
 
@@ -1327,8 +1312,7 @@ ngx_http_cache_purge_access_handler(ngx_http_request_t *r)
 
 ngx_int_t
 ngx_http_cache_purge_access(ngx_array_t *access, ngx_array_t *access6,
-    struct sockaddr *s)
-{
+                            struct sockaddr *s) {
     in_addr_t         inaddr;
     ngx_in_cidr_t    *a;
     ngx_uint_t        i;
@@ -1348,7 +1332,7 @@ ngx_http_cache_purge_access(ngx_array_t *access, ngx_array_t *access6,
         inaddr = ((struct sockaddr_in *) s)->sin_addr.s_addr;
 
 # if (NGX_HAVE_INET6)
-    ipv4:
+ipv4:
 # endif /* NGX_HAVE_INET6 */
 
         a = access->elts;
@@ -1389,7 +1373,7 @@ ngx_http_cache_purge_access(ngx_array_t *access, ngx_array_t *access6,
 
             return NGX_OK;
 
-        next:
+next:
             continue;
         }
 
@@ -1401,8 +1385,7 @@ ngx_http_cache_purge_access(ngx_array_t *access, ngx_array_t *access6,
 }
 
 ngx_int_t
-ngx_http_cache_purge_send_response(ngx_http_request_t *r)
-{
+ngx_http_cache_purge_send_response(ngx_http_request_t *r) {
     ngx_chain_t   out;
     ngx_buf_t    *b;
     ngx_str_t    *key;
@@ -1450,7 +1433,7 @@ ngx_http_cache_purge_send_response(ngx_http_request_t *r)
 
     rc = ngx_http_send_header(r);
     if (rc == NGX_ERROR || rc > NGX_OK || r->header_only) {
-       return rc;
+        return rc;
     }
 
     return ngx_http_output_filter(r, &out);
@@ -1465,8 +1448,7 @@ ngx_http_cache_purge_send_response(ngx_http_request_t *r)
  */
 ngx_int_t
 ngx_http_cache_purge_cache_get(ngx_http_request_t *r, ngx_http_upstream_t *u,
-    ngx_http_file_cache_t **cache)
-{
+                               ngx_http_file_cache_t **cache) {
     ngx_str_t               *name, val;
     ngx_uint_t               i;
     ngx_http_file_cache_t  **caches;
@@ -1481,8 +1463,7 @@ ngx_http_cache_purge_cache_get(ngx_http_request_t *r, ngx_http_upstream_t *u,
     }
 
     if (val.len == 0
-        || (val.len == 3 && ngx_strncmp(val.data, "off", 3) == 0))
-    {
+            || (val.len == 3 && ngx_strncmp(val.data, "off", 3) == 0)) {
         return NGX_DECLINED;
     }
 
@@ -1492,8 +1473,7 @@ ngx_http_cache_purge_cache_get(ngx_http_request_t *r, ngx_http_upstream_t *u,
         name = &caches[i]->shm_zone->shm.name;
 
         if (name->len == val.len
-            && ngx_strncmp(name->data, val.data, val.len) == 0)
-        {
+                && ngx_strncmp(name->data, val.data, val.len) == 0) {
             *cache = caches[i];
             return NGX_OK;
         }
@@ -1509,8 +1489,7 @@ ngx_http_cache_purge_cache_get(ngx_http_request_t *r, ngx_http_upstream_t *u,
 
 ngx_int_t
 ngx_http_cache_purge_init(ngx_http_request_t *r, ngx_http_file_cache_t *cache,
-    ngx_http_complex_value_t *cache_key)
-{
+                          ngx_http_complex_value_t *cache_key) {
     ngx_http_cache_t  *c;
     ngx_str_t         *key;
     ngx_int_t          rc;
@@ -1551,8 +1530,7 @@ ngx_http_cache_purge_init(ngx_http_request_t *r, ngx_http_file_cache_t *cache,
 }
 
 void
-ngx_http_cache_purge_handler(ngx_http_request_t *r)
-{
+ngx_http_cache_purge_handler(ngx_http_request_t *r) {
     ngx_http_cache_purge_loc_conf_t     *cplcf;
     ngx_int_t  rc;
 
@@ -1568,8 +1546,8 @@ ngx_http_cache_purge_handler(ngx_http_request_t *r)
         rc = ngx_http_file_cache_purge(r);
 
         ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                    "http file cache purge: %i, \"%s\"",
-                    rc, r->cache->file.name.data);
+                       "http file cache purge: %i, \"%s\"",
+                       rc, r->cache->file.name.data);
     }
 
     switch (rc) {
@@ -1591,8 +1569,7 @@ ngx_http_cache_purge_handler(ngx_http_request_t *r)
 }
 
 ngx_int_t
-ngx_http_file_cache_purge(ngx_http_request_t *r)
-{
+ngx_http_file_cache_purge(ngx_http_request_t *r) {
     ngx_http_file_cache_t  *cache;
     ngx_http_cache_t       *c;
 
@@ -1660,8 +1637,8 @@ ngx_http_file_cache_purge(ngx_http_request_t *r)
 void
 ngx_http_cache_purge_all(ngx_http_request_t *r, ngx_http_file_cache_t *cache) {
     ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                      "purge_all http in %s",
-                      cache->path->name.data);
+                  "purge_all http in %s",
+                  cache->path->name.data);
 
     /* Walk the tree and remove all the files */
     ngx_tree_ctx_t  tree;
@@ -1680,8 +1657,8 @@ ngx_http_cache_purge_all(ngx_http_request_t *r, ngx_http_file_cache_t *cache) {
 void
 ngx_http_cache_purge_partial(ngx_http_request_t *r, ngx_http_file_cache_t *cache) {
     ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                      "purge_partial http in %s",
-                      cache->path->name.data);
+                  "purge_partial http in %s",
+                  cache->path->name.data);
 
     u_char              *key_partial;
     ngx_str_t           *key;
@@ -1711,8 +1688,7 @@ ngx_http_cache_purge_partial(ngx_http_request_t *r, ngx_http_file_cache_t *cache
 }
 
 ngx_int_t
-ngx_http_cache_purge_is_partial(ngx_http_request_t *r)
-{
+ngx_http_cache_purge_is_partial(ngx_http_request_t *r) {
     ngx_str_t *key;
     ngx_http_cache_t  *c;
 
@@ -1724,8 +1700,7 @@ ngx_http_cache_purge_is_partial(ngx_http_request_t *r)
 }
 
 char *
-ngx_http_cache_purge_conf(ngx_conf_t *cf, ngx_http_cache_purge_conf_t *cpcf)
-{
+ngx_http_cache_purge_conf(ngx_conf_t *cf, ngx_http_cache_purge_conf_t *cpcf) {
     ngx_cidr_t       cidr;
     ngx_in_cidr_t   *access;
 # if (NGX_HAVE_INET6)
@@ -1842,8 +1817,7 @@ ngx_http_cache_purge_conf(ngx_conf_t *cf, ngx_http_cache_purge_conf_t *cpcf)
 
 void
 ngx_http_cache_purge_merge_conf(ngx_http_cache_purge_conf_t *conf,
-    ngx_http_cache_purge_conf_t *prev)
-{
+                                ngx_http_cache_purge_conf_t *prev) {
     if (conf->enable == NGX_CONF_UNSET) {
         if (prev->enable == 1) {
             conf->enable = prev->enable;
@@ -1859,8 +1833,7 @@ ngx_http_cache_purge_merge_conf(ngx_http_cache_purge_conf_t *conf,
 }
 
 void *
-ngx_http_cache_purge_create_loc_conf(ngx_conf_t *cf)
-{
+ngx_http_cache_purge_create_loc_conf(ngx_conf_t *cf) {
     ngx_http_cache_purge_loc_conf_t  *conf;
 
     conf = ngx_pcalloc(cf->pool, sizeof(ngx_http_cache_purge_loc_conf_t));
@@ -1897,8 +1870,7 @@ ngx_http_cache_purge_create_loc_conf(ngx_conf_t *cf)
 }
 
 char *
-ngx_http_cache_purge_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
-{
+ngx_http_cache_purge_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child) {
     ngx_http_cache_purge_loc_conf_t  *prev = parent;
     ngx_http_cache_purge_loc_conf_t  *conf = child;
     ngx_http_core_loc_conf_t         *clcf;
@@ -1926,7 +1898,7 @@ ngx_http_cache_purge_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
         if (flcf->upstream.upstream || flcf->fastcgi_lengths) {
             conf->conf = &conf->fastcgi;
             conf->handler = flcf->upstream.cache
-                          ? ngx_http_fastcgi_cache_purge_handler : NULL;
+                            ? ngx_http_fastcgi_cache_purge_handler : NULL;
             conf->original_handler = clcf->handler;
 
             clcf->handler = ngx_http_cache_purge_access_handler;
@@ -1945,7 +1917,7 @@ ngx_http_cache_purge_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
         if (plcf->upstream.upstream || plcf->proxy_lengths) {
             conf->conf = &conf->proxy;
             conf->handler = plcf->upstream.cache
-                          ? ngx_http_proxy_cache_purge_handler : NULL;
+                            ? ngx_http_proxy_cache_purge_handler : NULL;
             conf->original_handler = clcf->handler;
 
             clcf->handler = ngx_http_cache_purge_access_handler;
@@ -1964,7 +1936,7 @@ ngx_http_cache_purge_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
         if (slcf->upstream.upstream || slcf->scgi_lengths) {
             conf->conf = &conf->scgi;
             conf->handler = slcf->upstream.cache
-                          ? ngx_http_scgi_cache_purge_handler : NULL;
+                            ? ngx_http_scgi_cache_purge_handler : NULL;
             conf->original_handler = clcf->handler;
             clcf->handler = ngx_http_cache_purge_access_handler;
 
@@ -1982,7 +1954,7 @@ ngx_http_cache_purge_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
         if (ulcf->upstream.upstream || ulcf->uwsgi_lengths) {
             conf->conf = &conf->uwsgi;
             conf->handler = ulcf->upstream.cache
-                          ? ngx_http_uwsgi_cache_purge_handler : NULL;
+                            ? ngx_http_uwsgi_cache_purge_handler : NULL;
             conf->original_handler = clcf->handler;
 
             clcf->handler = ngx_http_cache_purge_access_handler;

--- a/ngx_cache_purge_module.c
+++ b/ngx_cache_purge_module.c
@@ -27,8 +27,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <nginx.h>
 #include <ngx_config.h>
+#include <nginx.h>
 #include <ngx_core.h>
 #include <ngx_http.h>
 

--- a/ngx_cache_purge_module.c
+++ b/ngx_cache_purge_module.c
@@ -1556,7 +1556,7 @@ ngx_http_cache_purge_handler(ngx_http_request_t *r) {
         ngx_http_finalize_request(r, ngx_http_cache_purge_send_response(r));
         return;
     case NGX_DECLINED:
-        ngx_http_finalize_request(r, NGX_HTTP_NOT_FOUND);
+        ngx_http_finalize_request(r, NGX_HTTP_PRECONDITION_FAILED);
         return;
 #  if (NGX_HAVE_FILE_AIO)
     case NGX_AGAIN:

--- a/ngx_cache_purge_module.c
+++ b/ngx_cache_purge_module.c
@@ -433,7 +433,7 @@ ngx_http_fastcgi_cache_purge_handler(ngx_http_request_t *r) {
 
     /* Purge-all option */
     cplcf = ngx_http_get_module_loc_conf(r, ngx_http_cache_purge_module);
-    if (cplcf->conf->purge_all) {
+    if (cplcf->fastcgi.purge_all) {
         ngx_http_cache_purge_all(r, cache);
     } else {
         if (ngx_http_cache_purge_is_partial(r)) {
@@ -719,7 +719,7 @@ ngx_http_proxy_cache_purge_handler(ngx_http_request_t *r) {
 
     /* Purge-all option */
     cplcf = ngx_http_get_module_loc_conf(r, ngx_http_cache_purge_module);
-    if (cplcf->conf->purge_all) {
+    if (cplcf->fastcgi.purge_all) {
         ngx_http_cache_purge_all(r, cache);
     } else {
         if (ngx_http_cache_purge_is_partial(r)) {
@@ -943,7 +943,7 @@ ngx_http_scgi_cache_purge_handler(ngx_http_request_t *r) {
 
     /* Purge-all option */
     cplcf = ngx_http_get_module_loc_conf(r, ngx_http_cache_purge_module);
-    if (cplcf->conf->purge_all) {
+    if (cplcf->fastcgi.purge_all) {
         ngx_http_cache_purge_all(r, cache);
     } else {
         if (ngx_http_cache_purge_is_partial(r)) {
@@ -1190,7 +1190,7 @@ ngx_http_uwsgi_cache_purge_handler(ngx_http_request_t *r) {
 
     /* Purge-all option */
     cplcf = ngx_http_get_module_loc_conf(r, ngx_http_cache_purge_module);
-    if (cplcf->conf->purge_all) {
+    if (cplcf->fastcgi.purge_all) {
         ngx_http_cache_purge_all(r, cache);
     } else {
         if (ngx_http_cache_purge_is_partial(r)) {
@@ -1542,7 +1542,7 @@ ngx_http_cache_purge_handler(ngx_http_request_t *r) {
 
     cplcf = ngx_http_get_module_loc_conf(r, ngx_http_cache_purge_module);
     rc = NGX_OK;
-    if (!cplcf->conf->purge_all && !ngx_http_cache_purge_is_partial(r)) {
+    if (!cplcf->fastcgi.purge_all && !ngx_http_cache_purge_is_partial(r)) {
         rc = ngx_http_file_cache_purge(r);
 
         ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,

--- a/ngx_cache_purge_module.c
+++ b/ngx_cache_purge_module.c
@@ -426,7 +426,7 @@ ngx_http_fastcgi_cache_purge_handler(ngx_http_request_t *r)
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
-    // Purge-all option
+    /* Purge-all option */
     cplcf = ngx_http_get_module_loc_conf(r, ngx_http_cache_purge_module);
     if (cplcf->conf->purge_all) {
         ngx_http_cache_purge_all(r, cache);
@@ -712,7 +712,7 @@ ngx_http_proxy_cache_purge_handler(ngx_http_request_t *r)
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
-    // Purge-all option
+    /* Purge-all option */
     cplcf = ngx_http_get_module_loc_conf(r, ngx_http_cache_purge_module);
     if (cplcf->conf->purge_all) {
         ngx_http_cache_purge_all(r, cache);
@@ -940,7 +940,7 @@ ngx_http_scgi_cache_purge_handler(ngx_http_request_t *r)
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
-    // Purge-all option
+    /* Purge-all option */
     cplcf = ngx_http_get_module_loc_conf(r, ngx_http_cache_purge_module);
     if (cplcf->conf->purge_all) {
         ngx_http_cache_purge_all(r, cache);
@@ -1191,7 +1191,7 @@ ngx_http_uwsgi_cache_purge_handler(ngx_http_request_t *r)
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
-    // Purge-all option
+    /* Purge-all option */
     cplcf = ngx_http_get_module_loc_conf(r, ngx_http_cache_purge_module);
     if (cplcf->conf->purge_all) {
         ngx_http_cache_purge_all(r, cache);
@@ -1248,7 +1248,7 @@ ngx_http_purge_file_cache_delete_partial_file(ngx_tree_ctx_t *ctx, ngx_str_t *pa
     key_partial = ctx->data;
     len = ngx_strlen(key_partial);
 
-    // if key_partial is empty always match, because is a *
+    /* if key_partial is empty always match, because is a '*' */
     if (len == 0) {
         ngx_log_debug(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
                       "empty key_partial, forcing deletion");
@@ -1261,12 +1261,15 @@ ngx_http_purge_file_cache_delete_partial_file(ngx_tree_ctx_t *ctx, ngx_str_t *pa
         file.fd = ngx_open_file(path->data, NGX_FILE_RDONLY, NGX_FILE_OPEN,
                             NGX_FILE_DEFAULT_ACCESS);
 
-        // I don't know if it's a good idea to use the ngx_cycle pool for this, but the request is not available here
+        /* I don't know if it's a good idea to use the ngx_cycle pool for this,
+           but the request is not available here */
         key_in_file = ngx_pcalloc(ngx_cycle->pool, sizeof(u_char) * (len + 1));
 
-        // KEY: /proxy/passwd
-        //  since we don't need the "KEY: " ignore 5 + 1 extra u_char from last intro
-        // Optimization: we don't need to read the full key only the n chars included in key_partial
+        /* KEY: /proxy/passwd */
+        /* since we don't need the "KEY: " ignore 5 + 1 extra u_char from last
+           intro */
+        /* Optimization: we don't need to read the full key only the n chars
+           included in key_partial */
         ngx_read_file(&file, key_in_file, sizeof(u_char) * len,
                       sizeof(ngx_http_file_cache_header_t) + sizeof(u_char) * 6);
         ngx_close_file(file.fd);
@@ -1656,7 +1659,7 @@ ngx_http_cache_purge_all(ngx_http_request_t *r, ngx_http_file_cache_t *cache) {
                       "purge_all http in %s",
                       cache->path->name.data);
 
-    // Walk the tree and remove all the files
+    /* Walk the tree and remove all the files */
     ngx_tree_ctx_t  tree;
     tree.init_handler = NULL;
     tree.file_handler = ngx_http_purge_file_cache_delete_file;
@@ -1685,11 +1688,11 @@ ngx_http_cache_purge_partial(ngx_http_request_t *r, ngx_http_file_cache_t *cache
     key = c->keys.elts;
     len = key[0].len;
 
-    // Only check the first key
+    /* Only check the first key */
     key_partial = ngx_pcalloc(r->pool, sizeof(u_char) * len);
     ngx_memcpy(key_partial, key[0].data, sizeof(u_char) * (len - 1));
 
-    // Walk the tree and remove all the files matching key_partial
+    /* Walk the tree and remove all the files matching key_partial */
     ngx_tree_ctx_t  tree;
     tree.init_handler = NULL;
     tree.file_handler = ngx_http_purge_file_cache_delete_partial_file;
@@ -1712,7 +1715,7 @@ ngx_http_cache_purge_is_partial(ngx_http_request_t *r)
     c = r->cache;
     key = c->keys.elts;
 
-    // Only check the first key
+    /* Only check the first key */
     return key[0].data[key[0].len - 1] == '*';
 }
 
@@ -1731,7 +1734,7 @@ ngx_http_cache_purge_conf(ngx_conf_t *cf, ngx_http_cache_purge_conf_t *cpcf)
 
     from_position = 2;
 
-    // xxx_cache_purge on|off|<method> [purge_all] [from all|<ip> [.. <ip>]]
+    /* xxx_cache_purge on|off|<method> [purge_all] [from all|<ip> [.. <ip>]] */
     value = cf->args->elts;
 
     if (ngx_strcmp(value[1].data, "off") == 0) {
@@ -1750,7 +1753,7 @@ ngx_http_cache_purge_conf(ngx_conf_t *cf, ngx_http_cache_purge_conf_t *cpcf)
         return NGX_CONF_OK;
     }
 
-    // We will purge all the keys
+    /* We will purge all the keys */
     if (ngx_strcmp(value[from_position].data, "purge_all") == 0) {
         cpcf->purge_all = 1;
         from_position++;

--- a/ngx_cache_purge_module.c
+++ b/ngx_cache_purge_module.c
@@ -113,6 +113,8 @@ ngx_int_t   ngx_http_file_cache_purge(ngx_http_request_t *r);
 
 
 void        ngx_http_cache_purge_all(ngx_http_request_t *r, ngx_http_file_cache_t *cache);
+void        ngx_http_cache_purge_partial(ngx_http_request_t *r, ngx_http_file_cache_t *cache);
+ngx_int_t   ngx_http_cache_purge_is_partial(ngx_http_request_t *r);
 
 char       *ngx_http_cache_purge_conf(ngx_conf_t *cf,
     ngx_http_cache_purge_conf_t *cpcf);
@@ -429,6 +431,14 @@ ngx_http_fastcgi_cache_purge_handler(ngx_http_request_t *r)
     if (cplcf->conf->purge_all) {
         ngx_http_cache_purge_all(r, cache);
     }
+    else {
+        if (ngx_http_cache_purge_is_partial(r)) {
+            ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http file cache purge with partial enabled");
+
+            ngx_http_cache_purge_partial(r, cache);
+        }
+    }
 
 #  if (nginx_version >= 8011)
     r->main->count++;
@@ -707,6 +717,14 @@ ngx_http_proxy_cache_purge_handler(ngx_http_request_t *r)
     if (cplcf->conf->purge_all) {
         ngx_http_cache_purge_all(r, cache);
     }
+    else {
+        if (ngx_http_cache_purge_is_partial(r)) {
+            ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http file cache purge with partial enabled");
+
+            ngx_http_cache_purge_partial(r, cache);
+        }
+    }
 
 #  if (nginx_version >= 8011)
     r->main->count++;
@@ -926,6 +944,14 @@ ngx_http_scgi_cache_purge_handler(ngx_http_request_t *r)
     cplcf = ngx_http_get_module_loc_conf(r, ngx_http_cache_purge_module);
     if (cplcf->conf->purge_all) {
         ngx_http_cache_purge_all(r, cache);
+    }
+    else {
+        if (ngx_http_cache_purge_is_partial(r)) {
+            ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http file cache purge with partial enabled");
+
+            ngx_http_cache_purge_partial(r, cache);
+        }
     }
 
 #  if (nginx_version >= 8011)
@@ -1170,6 +1196,14 @@ ngx_http_uwsgi_cache_purge_handler(ngx_http_request_t *r)
     if (cplcf->conf->purge_all) {
         ngx_http_cache_purge_all(r, cache);
     }
+    else {
+        if (ngx_http_cache_purge_is_partial(r)) {
+            ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http file cache purge with partial enabled");
+
+            ngx_http_cache_purge_partial(r, cache);
+        }
+    }
 
 #  if (nginx_version >= 8011)
     r->main->count++;
@@ -1197,6 +1231,59 @@ ngx_http_purge_file_cache_delete_file(ngx_tree_ctx_t *ctx, ngx_str_t *path)
     if (ngx_delete_file(path->data) == NGX_FILE_ERROR) {
         ngx_log_error(NGX_LOG_CRIT, ctx->log, ngx_errno,
                       ngx_delete_file_n " \"%s\" failed", path->data);
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_purge_file_cache_delete_partial_file(ngx_tree_ctx_t *ctx, ngx_str_t *path)
+{
+    u_char *key_partial;
+    u_char *key_in_file;
+    ngx_uint_t len;
+    ngx_flag_t remove_file = 0;
+
+    key_partial = ctx->data;
+    len = ngx_strlen(key_partial);
+
+    // if key_partial is empty always match, because is a *
+    if (len == 0) {
+        ngx_log_debug(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+                      "empty key_partial, forcing deletion");
+        remove_file = 1;
+    }
+    else {
+        ngx_file_t file;
+
+        file.offset = file.sys_offset = 0;
+        file.fd = ngx_open_file(path->data, NGX_FILE_RDONLY, NGX_FILE_OPEN,
+                            NGX_FILE_DEFAULT_ACCESS);
+
+        // I don't know if it's a good idea to use the ngx_cycle pool for this, but the request is not available here
+        key_in_file = ngx_pcalloc(ngx_cycle->pool, sizeof(u_char) * (len + 1));
+
+        // KEY: /proxy/passwd
+        //  since we don't need the "KEY: " ignore 5 + 1 extra u_char from last intro
+        // Optimization: we don't need to read the full key only the n chars included in key_partial
+        ngx_read_file(&file, key_in_file, sizeof(u_char) * len,
+                      sizeof(ngx_http_file_cache_header_t) + sizeof(u_char) * 6);
+        ngx_close_file(file.fd);
+
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+                        "http cache file \"%s\" key read: \"%s\"", path->data, key_in_file);
+
+        if (ngx_strncasecmp(key_in_file, key_partial, len) == 0) {
+            ngx_log_debug(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+                      "match found, deleting file \"%s\"", path->data);
+            remove_file = 1;
+        }
+    }
+
+    if (remove_file && ngx_delete_file(path->data) == NGX_FILE_ERROR) {
+        ngx_log_error(NGX_LOG_CRIT, ctx->log, ngx_errno,
+                        ngx_delete_file_n " \"%s\" failed", path->data);
     }
 
     return NGX_OK;
@@ -1469,15 +1556,13 @@ ngx_http_cache_purge_handler(ngx_http_request_t *r)
 #  endif
 
     cplcf = ngx_http_get_module_loc_conf(r, ngx_http_cache_purge_module);
-    if (cplcf->conf->purge_all) {
-        rc = NGX_OK;
-    }
-    else {
+    rc = NGX_OK;
+    if (!cplcf->conf->purge_all && !ngx_http_cache_purge_is_partial(r)) {
         rc = ngx_http_file_cache_purge(r);
 
         ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                   "http file cache purge: %i, \"%s\"",
-                   rc, r->cache->file.name.data);
+                    "http file cache purge: %i, \"%s\"",
+                    rc, r->cache->file.name.data);
     }
 
     switch (rc) {
@@ -1578,11 +1663,57 @@ ngx_http_cache_purge_all(ngx_http_request_t *r, ngx_http_file_cache_t *cache) {
     tree.pre_tree_handler = ngx_http_purge_file_cache_noop;
     tree.post_tree_handler = ngx_http_purge_file_cache_noop;
     tree.spec_handler = ngx_http_purge_file_cache_noop;
-    tree.data = cache;
+    tree.data = NULL;
     tree.alloc = 0;
     tree.log = ngx_cycle->log;
 
     ngx_walk_tree(&tree, &cache->path->name);
+}
+
+void
+ngx_http_cache_purge_partial(ngx_http_request_t *r, ngx_http_file_cache_t *cache) {
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                      "purge_partial http in %s",
+                      cache->path->name.data);
+
+    u_char              *key_partial;
+    ngx_str_t           *key;
+    ngx_http_cache_t    *c;
+    ngx_uint_t          len;
+
+    c = r->cache;
+    key = c->keys.elts;
+    len = key[0].len;
+
+    // Only check the first key
+    key_partial = ngx_pcalloc(r->pool, sizeof(u_char) * len);
+    ngx_memcpy(key_partial, key[0].data, sizeof(u_char) * (len - 1));
+
+    // Walk the tree and remove all the files matching key_partial
+    ngx_tree_ctx_t  tree;
+    tree.init_handler = NULL;
+    tree.file_handler = ngx_http_purge_file_cache_delete_partial_file;
+    tree.pre_tree_handler = ngx_http_purge_file_cache_noop;
+    tree.post_tree_handler = ngx_http_purge_file_cache_noop;
+    tree.spec_handler = ngx_http_purge_file_cache_noop;
+    tree.data = key_partial;
+    tree.alloc = 0;
+    tree.log = ngx_cycle->log;
+
+    ngx_walk_tree(&tree, &cache->path->name);
+}
+
+ngx_int_t
+ngx_http_cache_purge_is_partial(ngx_http_request_t *r)
+{
+    ngx_str_t *key;
+    ngx_http_cache_t  *c;
+
+    c = r->cache;
+    key = c->keys.elts;
+
+    // Only check the first key
+    return key[0].data[key[0].len - 1] == '*';
 }
 
 char *

--- a/t/proxy3.t
+++ b/t/proxy3.t
@@ -1,0 +1,140 @@
+# vi:filetype=perl
+
+use lib 'lib';
+use Test::Nginx::Socket;
+
+repeat_each(1);
+
+plan tests => 32;
+
+our $http_config = <<'_EOC_';
+    proxy_cache_path  /tmp/ngx_cache_purge_cache keys_zone=test_cache:10m;
+    proxy_temp_path   /tmp/ngx_cache_purge_temp 1 2;
+_EOC_
+
+our $config = <<'_EOC_';
+    location /proxy {
+        proxy_pass         $scheme://127.0.0.1:$server_port/etc/passwd;
+        proxy_cache        test_cache;
+        proxy_cache_key    $uri$is_args$args;
+        proxy_cache_valid  3m;
+        add_header         X-Cache-Status $upstream_cache_status;
+
+        proxy_cache_purge PURGE purge_all from 1.0.0.0/8 127.0.0.0/8 3.0.0.0/8;
+    }
+
+
+    location = /etc/passwd {
+        root               /var/www/html;
+    }
+_EOC_
+
+worker_connections(128);
+no_shuffle();
+run_tests();
+
+no_diff();
+
+__DATA__
+
+=== TEST 1: prepare passwd
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/passwd
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+
+
+=== TEST 2: prepare shadow
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/shadow
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+
+
+
+=== TEST 3: get from cache passwd
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/passwd
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+X-Cache-Status: HIT
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+
+
+=== TEST 4: get from cache shadow
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/shadow
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+X-Cache-Status: HIT
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+
+
+=== TEST 5: purge from cache
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+PURGE /proxy/any
+--- error_code: 200
+--- response_headers
+Content-Type: text/html
+--- response_body_like: Successful purge
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+
+
+=== TEST 6: get from empty cache passwd
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/passwd
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+X-Cache-Status: MISS
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+
+
+=== TEST 7: get from empty cache shadow
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/shadow
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+X-Cache-Status: MISS
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/

--- a/t/proxy4.t
+++ b/t/proxy4.t
@@ -1,0 +1,168 @@
+# vi:filetype=perl
+
+use lib 'lib';
+use Test::Nginx::Socket;
+
+repeat_each(1);
+
+plan tests => 41;
+
+our $http_config = <<'_EOC_';
+    proxy_cache_path  /tmp/ngx_cache_purge_cache keys_zone=test_cache:10m;
+    proxy_temp_path   /tmp/ngx_cache_purge_temp 1 2;
+_EOC_
+
+our $config = <<'_EOC_';
+    location /proxy {
+        proxy_pass         $scheme://127.0.0.1:$server_port/etc/passwd;
+        proxy_cache        test_cache;
+        proxy_cache_key    $uri$is_args$args;
+        proxy_cache_valid  3m;
+        add_header         X-Cache-Status $upstream_cache_status;
+
+        proxy_cache_purge PURGE from 1.0.0.0/8 127.0.0.0/8 3.0.0.0/8;
+    }
+
+
+    location = /etc/passwd {
+        root               /var/www/html;
+    }
+_EOC_
+
+worker_connections(128);
+no_shuffle();
+run_tests();
+
+no_diff();
+
+__DATA__
+
+=== TEST 1: prepare passwd
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/passwd
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+
+
+=== TEST 2: prepare passwd2
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/passwd2
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+
+
+=== TEST 3: prepare shadow
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/shadow
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+
+
+=== TEST 4: get from cache passwd
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/passwd
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+X-Cache-Status: HIT
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+
+
+=== TEST 5: get from cache passwd2
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/passwd2
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+X-Cache-Status: HIT
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+
+
+=== TEST 6: purge from cache
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+PURGE /proxy/pass*
+--- error_code: 200
+--- response_headers
+Content-Type: text/html
+--- response_body_like: Successful purge
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+
+
+=== TEST 7: get from empty cache passwd
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/passwd
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+X-Cache-Status: MISS
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+
+
+=== TEST 8: get from empty cache passwd2
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/passwd2
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+X-Cache-Status: MISS
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+
+
+=== TEST 9: get from cache shadow
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/shadow
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+X-Cache-Status: HIT
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/


### PR DESCRIPTION
Segmentation Fault when trying to purge all the content from nginx cache.
cplcf->conf value was 0x0.
Fixed by changing cplcf structure field accessed to cplcf->fastcgi.purge_all.